### PR TITLE
Fixes inherits with eager-loaded associations returning the wrong records.

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -25,45 +25,28 @@ module ActiveRecordInheritAssocPrepend
   end
 end
 
-ActiveRecord::Associations::Association.class_eval do
-  prepend ActiveRecordInheritAssocPrepend
-end
+ActiveRecord::Associations::Association.send(:prepend, ActiveRecordInheritAssocPrepend)
 
 module ActiveRecordInheritPreloadAssocPrepend
-  def self.prepended(mod)
-    mod.class_eval do
-      alias_method_chain :associated_records_by_owner, :inherit
+  def associated_records_by_owner(*args)
+    super.tap do |result|
+      next unless reflection.options[:inherit]
+      result.each do |owner, associated_records|
+        filter_associated_records_with_inherit!(owner, associated_records)
+      end
     end
   end
 
   def filter_associated_records_with_inherit!(owner, associated_records)
-    return unless reflection.options[:inherit]
-
     associated_records.select! do |record|
-      Array(reflection.options[:inherit]).all? do |obj|
-        record.send(obj) == owner.send(obj)
-      end
-    end
-  end
-
-  if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1
-    def associated_records_by_owner_with_inherit(preloader)
-      associated_records_by_owner_without_inherit(preloader).tap do |result|
-        result.each(&method(:filter_associated_records_with_inherit!)) if reflection.options[:inherit]
-      end
-    end
-  else
-    def associated_records_by_owner_with_inherit
-      associated_records_by_owner_without_inherit.tap do |result|
-        result.each(&method(:filter_associated_records_with_inherit!)) if reflection.options[:inherit]
+      Array(reflection.options[:inherit]).all? do |method_name|
+        record.send(method_name) == owner.send(method_name)
       end
     end
   end
 end
 
-ActiveRecord::Associations::Preloader::Association.class_eval do
-  prepend ActiveRecordInheritPreloadAssocPrepend
-end
+ActiveRecord::Associations::Preloader::Association.send(:prepend, ActiveRecordInheritPreloadAssocPrepend)
 
 class ActiveRecord::Base
   # Makes the model inherit the specified attribute from a named association.

--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -21,7 +21,7 @@ module ActiveRecordInheritAssocPrepend
 
   def attribute_inheritance_hash
     return nil unless reflection.options[:inherit]
-    Array(reflection.options[:inherit]).inject({}) { |hash, obj| hash[obj] = owner.send(obj) ; hash }
+    Array(reflection.options[:inherit]).inject({}) { |hash, association| hash[association] = owner.send(association) ; hash }
   end
 end
 
@@ -30,17 +30,17 @@ ActiveRecord::Associations::Association.send(:prepend, ActiveRecordInheritAssocP
 module ActiveRecordInheritPreloadAssocPrepend
   def associated_records_by_owner(*args)
     super.tap do |result|
-      next unless reflection.options[:inherit]
+      next unless inherit = reflection.options[:inherit]
       result.each do |owner, associated_records|
-        filter_associated_records_with_inherit!(owner, associated_records)
+        filter_associated_records_with_inherit!(owner, associated_records, inherit)
       end
     end
   end
 
-  def filter_associated_records_with_inherit!(owner, associated_records)
+  def filter_associated_records_with_inherit!(owner, associated_records, inherit)
     associated_records.select! do |record|
-      Array(reflection.options[:inherit]).all? do |method_name|
-        record.send(method_name) == owner.send(method_name)
+      Array(inherit).all? do |association|
+        record.send(association) == owner.send(association)
       end
     end
   end

--- a/test/test_inherit_assoc.rb
+++ b/test/test_inherit_assoc.rb
@@ -70,6 +70,32 @@ class TestInheritAssoc < ActiveSupport::TestCase
     assert_equal third_2, main.third
   end
 
+  def test_has_one_should_set_conditions_on_includes
+    main = Main.create! :account_id => 1
+
+    third_1 = Third.create! :main_id => main.id, :account_id => 2
+    third_2 = Third.create! :main_id => main.id, :account_id => 1
+
+    mains = Main.where(id: main.id).includes(:third)
+
+    assert_equal third_2, mains.first.third
+  end
+
+  def test_has_one_should_set_conditions_on_includes_with_multiple_owners
+    main_1 = Main.create! :account_id => 1
+    main_2 = Main.create! :account_id => 1
+
+    third_1 = Third.create! :main_id => main_1.id, :account_id => 2
+    third_2 = Third.create! :main_id => main_1.id, :account_id => 1
+    third_3 = Third.create! :main_id => main_2.id, :account_id => 2
+    third_4 = Third.create! :main_id => main_2.id, :account_id => 1
+
+    mains = Main.where(id: [main_1.id, main_2.id]).includes(:third)
+
+    assert_equal third_2, mains.first.third
+    assert_equal third_4, mains.last.third
+  end
+
   def test_has_many_should_set_conditions_for_multiple_inherits
     main = Main.create! :account_id => 1, :blah_id => 10
     # these two should match

--- a/test/test_inherit_assoc.rb
+++ b/test/test_inherit_assoc.rb
@@ -96,6 +96,32 @@ class TestInheritAssoc < ActiveSupport::TestCase
     assert_equal third_4, mains.last.third
   end
 
+  def test_has_many_should_set_conditions_on_includes
+    main = Main.create! :account_id => 1, :blah_id => 10
+
+    fourth_1 = Fourth.create! :main_id => main.id, :account_id => 2, :blah_id => 10
+    fourth_2 = Fourth.create! :main_id => main.id, :account_id => 1, :blah_id => 10
+
+    mains = Main.where(id: main.id).includes(:fourths)
+
+    assert_equal [fourth_2], mains.first.fourths
+  end
+
+  def test_has_many_should_set_conditions_on_includes_with_multiple_owners
+    main_1 = Main.create! :account_id => 1, :blah_id => 10
+    main_2 = Main.create! :account_id => 1, :blah_id => 20
+
+    fourth_1 = Fourth.create! :main_id => main_1.id, :account_id => 2, :blah_id => 10
+    fourth_2 = Fourth.create! :main_id => main_1.id, :account_id => 1, :blah_id => 10
+    fourth_3 = Fourth.create! :main_id => main_2.id, :account_id => 2, :blah_id => 20
+    fourth_4 = Fourth.create! :main_id => main_2.id, :account_id => 1, :blah_id => 20
+
+    mains = Main.where(id: [main_1.id, main_2.id]).includes(:fourths)
+
+    assert_equal [fourth_2], mains.first.fourths
+    assert_equal [fourth_4], mains.last.fourths
+  end
+
   def test_has_many_should_set_conditions_for_multiple_inherits
     main = Main.create! :account_id => 1, :blah_id => 10
     # these two should match


### PR DESCRIPTION
@grosser @pschambacher @osheroff this PR addresses an issue where `:inherit` with `ActiveRecord::QueryMethods#includes` returns the wrong record since the eager-loaded records aren't scoped by the `:inherit` conditions.

One approach would be to actually scope the eager-loaded records. However, with multiple owners, we would have to make one query for each owner (essentially re-introducing an N+1).

This PR takes the stance that we are okay with loading more records than intended if it means less SQL queries. And we can filter out wrong records in ruby.