### PR TITLE
skip statement cache on inherited associations

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -33,6 +33,10 @@ module ActiveRecordInheritAssocPrepend
     return nil unless reflection.options[:inherit]
     Array(reflection.options[:inherit]).inject({}) { |hash, association| hash[association] = owner.send(association) ; hash }
   end
+
+  def skip_statement_cache?
+    super || !!reflection.options[:inherit]
+  end
 end
 
 ActiveRecord::Associations::Association.send(:prepend, ActiveRecordInheritAssocPrepend)

--- a/test/test_inherit_assoc.rb
+++ b/test/test_inherit_assoc.rb
@@ -165,4 +165,16 @@ class TestInheritAssoc < ActiveSupport::TestCase
     other = main.create_third
     assert_equal main.account_id, other.account_id
   end
+
+  def test_association_caching_fail
+    main_1 = Main.create!(account_id: 1)
+    third_1 = Third.create!(main_id: main_1.id, account_id: 1)
+
+    assert_equal third_1, main_1.third
+
+    main_2 = Main.create!(account_id: 2)
+    third_2 = Third.create!(main_id: main_2.id, account_id: 2)
+
+    assert_equal third_2, main_2.third # this will fail, commenting out the previous assertion will make it pass.
+  end
 end


### PR DESCRIPTION
rails 4.2+ is agressively caching prepared statements for associations, not realizing that we were monkeying about with the scope.  This led us to incorrectly execute the first bit of SQL generated.

@JaredShay @zendesk/infrastructure @grosser 
