### PR TITLE
skip the statement cache for inherit associations

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -34,7 +34,7 @@ module ActiveRecordInheritAssocPrepend
     Array(reflection.options[:inherit]).inject({}) { |hash, association| hash[association] = owner.send(association) ; hash }
   end
 
-  if ActiveRecord::VERSION::MAJOR == 4
+  if ActiveRecord::VERSION::MAJOR >= 4
     def skip_statement_cache?
       super || !!reflection.options[:inherit]
     end

--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -33,6 +33,12 @@ module ActiveRecordInheritAssocPrepend
     return nil unless reflection.options[:inherit]
     Array(reflection.options[:inherit]).inject({}) { |hash, association| hash[association] = owner.send(association) ; hash }
   end
+
+  if ActiveRecord::VERSION::MAJOR == 4
+    def skip_statement_cache?
+      super || !!reflection.options[:inherit]
+    end
+  end
 end
 
 ActiveRecord::Associations::Association.send(:prepend, ActiveRecordInheritAssocPrepend)

--- a/test/test_inherit_assoc.rb
+++ b/test/test_inherit_assoc.rb
@@ -165,4 +165,16 @@ class TestInheritAssoc < ActiveSupport::TestCase
     other = main.create_third
     assert_equal main.account_id, other.account_id
   end
+
+  def test_association_caching_fail
+    main_1 = Main.create!(account_id: 1)
+    third_1 = Third.create!(main_id: main_1.id, account_id: 1)
+
+    assert_equal third_1, main_1.third
+
+    main_2 = Main.create!(account_id: 2)
+    third_2 = Third.create!(main_id: main_2.id, account_id: 2)
+
+    assert_equal third_2, main_2.third # this will fail, commenting out the previous assertion will make it pass.
+  end
 end


### PR DESCRIPTION
In rails 4.2 associations with the `inherit` option seem to be pulling
in old cached values. This tells the association to skip the statement
cache if the association has `inherit`.

This is just bringing back #10 but only for active record 4. 

/cc @zendesk/classic-upgrade 