### PR TITLE
Compatibility with Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,16 @@ sudo: false
 branches:
   only: master
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2
+  - 2.3
+  - 2.4
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
+  - gemfiles/rails5.2.gemfile
 matrix:
   exclude:
-    - rvm: 2.4.1
+    - rvm: 2.4
       gemfile: gemfiles/rails3.2.gemfile

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,4 +1,4 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 3.2.22'
 gem 'minitest', '~> 4.7.0'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 4.2.5', :require=> 'active_record'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 5.0.2', :require=> 'active_record'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,3 +1,3 @@
-eval_gemfile('gemfiles/common.rb')
+eval_gemfile('common.rb')
 
 gem 'activerecord', '~> 5.1.1', :require=> 'active_record'

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile('common.rb')
+
+gem 'activerecord', '~> 5.2.0.beta2', require: 'active_record'
+gem 'rails',        '~> 5.2.0.beta2'


### PR DESCRIPTION
/cc @zendesk/zendesk-rails-upgraders 

This was no fun at all...
So the logic around preloading change in [this PR](https://github.com/rails/rails/pull/22115/files) which made the method we overloaded useless and somebody removed it in [this PR](https://github.com/rails/rails/commit/3f1695bb9c008b7cb1840e09e640f3ec0c59a564)
We can keep the gem working by hacking into the new method introduced and pre-process the records before they're passed to be set on the owners.