### PR TITLE
:inherit associations should properly scope :through joins

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -31,7 +31,12 @@ module ActiveRecordInheritAssocPrepend
 
   def attribute_inheritance_hash
     return nil unless reflection.options[:inherit]
-    Array(reflection.options[:inherit]).inject({}) { |hash, association| hash[association] = owner.send(association) ; hash }
+    Array(reflection.options[:inherit]).inject({}) do |hash, association|
+      assoc_value = owner.send(association)
+      hash[association] = assoc_value
+      hash["#{through_reflection.table_name}.#{association}"] = assoc_value if reflection.options.key?(:through)
+      hash
+    end
   end
 
   if ActiveRecord::VERSION::MAJOR >= 4

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -25,4 +25,17 @@ ActiveRecord::Schema.define(:version => 1) do
     t.integer :account_id
     t.integer :blah_id
   end
+
+  drop_table(:fifths) rescue nil
+  create_table "fifths" do |t|
+    t.integer :main_id
+    t.integer :account_id
+    t.integer :sixth_id
+  end
+
+  drop_table(:sixths) rescue nil
+  create_table "sixths" do |t|
+    t.integer :main_id
+    t.integer :account_id
+  end
 end


### PR DESCRIPTION
/cc @craig-day @staugaard @grosser @bquorning @ggrossman @hsume2 

Attempting to get `:through` joins with `:inherit` to add constraints on the join table.

For example, Classic includes code like:

```
class Group < ActiveRecord::Base
  has_many :users, through: :memberships, source: :user, order: 'users.name', conditions: 'users.is_active = 1', inherit: :account_id
end

class Membership < ActiveRecord::Base
  belongs_to :group, inherit: :account_id
  belongs_to :user, inherit: :account_id
end
```
Calling `acct.groups.first.users` generates SQL like:
```
SELECT `users`.* FROM `users` INNER JOIN `memberships` ON `users`.`id` = `memberships`.`user_id` WHERE `users`.`account_id` = 1 AND `memberships`.`group_id` = 10002 AND (users.is_active = 1) ORDER BY users.name
```
Note that there's no constraint on `memberships.account_id`.

With this change the generated SQL looks like:
```
SELECT `users`.* FROM `users` INNER JOIN `memberships` ON `users`.`id` = `memberships`.`user_id` WHERE `users`.`account_id` = 1 AND `memberships`.`account_id` = 1 AND `memberships`.`group_id` = 10002 AND (users.is_active = 1) ORDER BY users.name
```

For background, this is intended to help with the `Pod15` incident.  We now have instances with duplicate IDs, but with different account_ids.  We haven't yet seen a conflict, since the items with duplicate IDs are currently in different shards, but Exodus moves or other changes may cause ID conflicts within a single shard.  We intend to change the primary keys of essentially all tables to be like [`id`, `account_id`], instead of the current primary keys like [`id`].