### PR TITLE
patch scope in preloader to correctly inherit

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -68,10 +68,9 @@ module ActiveRecordInheritPreloadAssocPrepend
     prescope = super
 
     if inherit = reflection.options[:inherit]
-      owner = owners.first
-
       Array(inherit).each do |inherit_assoc|
-        prescope = prescope.where(inherit_assoc => owner.send(inherit_assoc))
+        owner_values = owners.map(&inherit_assoc).compact.uniq
+        prescope = prescope.where(inherit_assoc => owner_values)
       end
     end
 

--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -37,7 +37,7 @@ module ActiveRecordInheritAssocPrepend
 
   if ActiveRecord::VERSION::MAJOR >= 4
     def skip_statement_cache?(*)
-      super || reflection.options.key?(:inherit)
+      super || !!reflection.options[:inherit]
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,4 +12,11 @@ require_relative "schema"
 
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)
 
+def capture_queries(&block)
+  queries = []
+  logger = ->(_n, _s, _f, _id, data) { queries << data[:sql] }
+  ActiveSupport::Notifications.subscribed(logger, 'sql.active_record', &block)
+  queries
+end
+
 require 'active_record_inherit_assoc'

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -19,15 +19,6 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
     belongs_to :main, :inherit => :account_id
   end
 
-  class Fifth < ActiveRecord::Base
-    belongs_to :main, :inherit => :account_id
-    belongs_to :sixth, :inherit => :account_id
-  end
-
-  class Sixth < ActiveRecord::Base
-    belongs_to :main, :inherit => :account_id
-  end
-
   describe 'generated sql queries' do
     let(:query) { Main.first }
 
@@ -36,10 +27,15 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
     }
 
     before do
+      Main.delete_all
+      Other.delete_all
+      Third.delete_all
+      Fourth.delete_all
+
       main = Main.create!(account_id: 100, blah_id: 200)
-      Other.create!(main: main)
-      Third.create!(main: main)
-      Fourth.create!(main: main)
+      Other.create!(main: main, account_id: 100)
+      Third.create!(main: main, account_id: 100)
+      Fourth.create!(main: main, account_id: 100, blah_id: 200)
     end
 
     describe 'has_many' do
@@ -59,6 +55,28 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
           assert_equal 2, queries.size
           assert_match /WHERE.*others.\..account_id/i, queries.last
         end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Other.create!(main: main, account_id: 777)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                others = main.others.to_a
+
+                assert_equal 1, others.size
+                assert_equal main.account_id, others.first.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
+        end
       end
 
       describe 'preloading using .preload' do
@@ -68,12 +86,38 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
           assert_equal 2, queries.size
           assert_match /WHERE.*others.\..account_id/i, queries.last
         end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Other.create!(main: main, account_id: 777)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                others = main.others.to_a
+
+                assert_equal 1, others.size
+                assert_equal main.account_id, others.first.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
+        end
       end
     end
 
     describe 'has_one' do
       describe 'loading a single record' do
         let(:query) { Main.first.third }
+
+        let(:queries) {
+          capture_queries { query }
+        }
 
         it 'correctly inherits' do
           assert_equal 2, queries.size
@@ -88,14 +132,52 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
           assert_equal 2, queries.size
           assert_match /WHERE.*thirds.\..account_id/i, queries.last
         end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Third.create!(main: main, account_id: 777)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                assert_equal main.account_id, main.third.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
+        end
       end
 
       describe 'preloading using .preload' do
-        let(:query) { Main.all.preload(:third) }
+        let(:query) { Main.preload(:third).all }
 
         it 'correctly inherits' do
           assert_equal 2, queries.size
           assert_match /WHERE.*thirds.\..account_id/i, queries.last
+        end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Third.create!(main: main, account_id: 777)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                assert_equal main.account_id, main.third.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
         end
       end
     end
@@ -119,6 +201,28 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
           assert_match /WHERE.*fourths.\..account_id/i, queries.last
           assert_match /WHERE.*fourths.\..blah_id/i, queries.last
         end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Fourth.create!(main: main, account_id: 777, blah_id: 999)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                fourths = main.fourths.to_a
+
+                assert_equal 1, fourths.size
+                assert_equal main.account_id, fourths.first.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
+        end
       end
 
       describe 'preloading using .preload' do
@@ -128,6 +232,28 @@ class TestInheritAssocQueries < ActiveSupport::TestCase
           assert_equal 2, queries.size
           assert_match /WHERE.*fourths.\..account_id/i, queries.last
           assert_match /WHERE.*fourths.\..blah_id/i, queries.last
+        end
+
+        describe 'loading many records with different values for the inherited association' do
+          before do
+            main = Main.create!(account_id: 777, blah_id: 999)
+            Fourth.create!(main: main, account_id: 777, blah_id: 999)
+          end
+
+          it 'correctly maps based on inherited association' do
+            results = query.to_a
+
+            subsequent_queries = capture_queries do
+              results.each do |main|
+                fourths = main.fourths.to_a
+
+                assert_equal 1, fourths.size
+                assert_equal main.account_id, fourths.first.account_id
+              end
+            end
+
+            assert_equal 0, subsequent_queries.size
+          end
         end
       end
     end

--- a/test/test_queries.rb
+++ b/test/test_queries.rb
@@ -1,0 +1,135 @@
+require_relative 'helper'
+
+class TestInheritAssocQueries < ActiveSupport::TestCase
+  class Main < ActiveRecord::Base
+    has_many :others, :inherit => :account_id
+    has_one :third, :inherit => :account_id
+    has_many :fourths, :inherit => [:account_id, :blah_id]
+  end
+
+  class Other < ActiveRecord::Base
+    belongs_to :main, :inherit => :account_id
+  end
+
+  class Third < ActiveRecord::Base
+    belongs_to :main, :inherit => :account_id
+  end
+
+  class Fourth < ActiveRecord::Base
+    belongs_to :main, :inherit => :account_id
+  end
+
+  class Fifth < ActiveRecord::Base
+    belongs_to :main, :inherit => :account_id
+    belongs_to :sixth, :inherit => :account_id
+  end
+
+  class Sixth < ActiveRecord::Base
+    belongs_to :main, :inherit => :account_id
+  end
+
+  describe 'generated sql queries' do
+    let(:query) { Main.first }
+
+    let(:queries) {
+      capture_queries { query.to_a }
+    }
+
+    before do
+      main = Main.create!(account_id: 100, blah_id: 200)
+      Other.create!(main: main)
+      Third.create!(main: main)
+      Fourth.create!(main: main)
+    end
+
+    describe 'has_many' do
+      describe 'loading a single record' do
+        let(:query) { Main.first.others }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*others.\..account_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .includes' do
+        let(:query) { Main.includes(:others).all }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*others.\..account_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .preload' do
+        let(:query) { Main.all.preload(:others) }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*others.\..account_id/i, queries.last
+        end
+      end
+    end
+
+    describe 'has_one' do
+      describe 'loading a single record' do
+        let(:query) { Main.first.third }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*thirds.\..account_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .includes' do
+        let(:query) { Main.includes(:third).all }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*thirds.\..account_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .preload' do
+        let(:query) { Main.all.preload(:third) }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*thirds.\..account_id/i, queries.last
+        end
+      end
+    end
+
+    describe 'has_many with multiple inherits' do
+      describe 'loading a single record' do
+        let(:query) { Main.first.fourths }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*fourths.\..account_id/i, queries.last
+          assert_match /WHERE.*fourths.\..blah_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .includes' do
+        let(:query) { Main.includes(:fourths).all }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*fourths.\..account_id/i, queries.last
+          assert_match /WHERE.*fourths.\..blah_id/i, queries.last
+        end
+      end
+
+      describe 'preloading using .preload' do
+        let(:query) { Main.all.preload(:fourths) }
+
+        it 'correctly inherits' do
+          assert_equal 2, queries.size
+          assert_match /WHERE.*fourths.\..account_id/i, queries.last
+          assert_match /WHERE.*fourths.\..blah_id/i, queries.last
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds in a scope patch so when you use any of the activerecord preloader things, we issue the preload queries with the inherited scope as well. 

For example, before this patch the query `Main.preload(:others).all.to_a` would issue a query to `others` that looked like 

```
... WHERE others.main_id = ?
```

Now, it will issue a query like 

```
... WHERE others.account_id = ? AND others.main_id = ?
```

Which is more correct because we told the `others` association to inherit the `account_id` attribute. See the added tests for more details. 

Related, I'm pretty sure there is a bug, or lack of feature, where we don't inherit associations on anything other that select statements. I would expect something like `Other.create!(main: main)` to create a record in the others table that has `main_id = {main.id}, account_id = {main.account_id}`, but in my new test, the records in the `others` table have `account_id = null`. I'll explore this in a further PR. 

This same reason is why the new test isn't testing the through association. Because the records on the through don't have the inherited value, they aren't found. 