### PR TITLE
Inherit if option

### DIFF
--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -3,6 +3,7 @@ require 'active_record'
 case ActiveRecord::VERSION::MAJOR
 when 4
   ActiveRecord::Associations::Builder::Association.valid_options << :inherit
+  ActiveRecord::Associations::Builder::Association.valid_options << :inherit_if
 when 5
   # We can't add options into `valid_options` anymore.
   # Here are the possible solutions:
@@ -12,6 +13,7 @@ when 5
   #
   # I went with the first one out of simplicity.
   ActiveRecord::Associations::Builder::Association::VALID_OPTIONS << :inherit
+  ActiveRecord::Associations::Builder::Association::VALID_OPTIONS << :inherit_if
 end
 
 module ActiveRecordInheritAssocPrepend
@@ -30,6 +32,7 @@ module ActiveRecordInheritAssocPrepend
 
     Array(reflection.options[:inherit]).each_with_object({}) do |association, hash|
       assoc_value = owner.send(association)
+      next if reflection.options[:inherit_if] && !reflection.options[:inherit_if].call(owner)
       hash[association] = assoc_value
       hash["#{through_reflection.table_name}.#{association}"] = assoc_value if reflection.options.key?(:through)
     end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -37,5 +37,12 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table "sixths" do |t|
     t.integer :main_id
     t.integer :account_id
+    t.integer :seventh_id
+  end
+
+  drop_table(:sevenths) rescue nil
+  create_table "sevenths" do |t|
+    t.integer :main_id
+    t.integer :account_id
   end
 end

--- a/test/test_inherit_assoc.rb
+++ b/test/test_inherit_assoc.rb
@@ -2,6 +2,8 @@ require_relative 'helper'
 
 class TestInheritAssoc < ActiveSupport::TestCase
   class Main < ActiveRecord::Base
+    attr_accessor :aux
+
     has_many :others, :inherit => :account_id
     has_one :third, :inherit => :account_id
     has_many :fourths, :inherit => [:account_id, :blah_id]
@@ -10,6 +12,7 @@ class TestInheritAssoc < ActiveSupport::TestCase
     end
     has_many :fifths, :inherit => :account_id
     has_many :sixths, :through => :fifths, inherit: :account_id
+    has_many :sevenths, :inherit => :account_id, :inherit_if => Proc.new { |m| m.aux }
   end
 
   class Other < ActiveRecord::Base
@@ -30,7 +33,14 @@ class TestInheritAssoc < ActiveSupport::TestCase
   end
 
   class Sixth < ActiveRecord::Base
+    attr_accessor :aux
+
     belongs_to :main
+    belongs_to :seventh, inherit: :account_id, inherit_if: Proc.new { |sixth| sixth.aux }
+  end
+
+  class Seventh < ActiveRecord::Base
+    belongs_to :main, inherit: :account_id
   end
 
   describe "Main, with some others, scoped by account_id" do
@@ -206,5 +216,35 @@ class TestInheritAssoc < ActiveSupport::TestCase
     third_2 = Third.create!(main_id: main_2.id, account_id: 2)
 
     assert_equal third_2, main_2.third # this will fail, commenting out the previous assertion will make it pass.
+  end
+
+  def test_association_with_inherit_if_in_belongs_to
+    main_1 = Main.create!(account_id: 1)
+
+    seventh_1 = Seventh.create! :account_id => 1
+    sixth_1 = Sixth.create! :main_id => main_1.id, :account_id => 1, seventh_id: seventh_1.id, :aux => true
+    assert_equal seventh_1, sixth_1.seventh
+
+    seventh_2 = Seventh.create! :account_id => 1
+    sixth_2 = Sixth.create! :main_id => main_1.id, :account_id => 2, seventh_id: seventh_2.id, :aux => true
+    assert_equal nil, sixth_2.seventh
+
+    seventh_3 = Seventh.create! :account_id => 1
+    sixth_3 = Sixth.create! :main_id => main_1.id, :account_id => 2, seventh_id: seventh_3.id, :aux => false
+    assert_equal seventh_3, sixth_3.seventh
+  end
+
+  def test_association_with_inherit_if_in_has_many
+    main_1 = Main.create!(account_id: 1, aux: true)
+    seventh_1 = Seventh.create! :account_id => 1, :main_id => main_1.id
+    assert_equal [seventh_1], main_1.sevenths
+
+    main_2 = Main.create!(account_id: 1, aux: true)
+    seventh_2 = Seventh.create! :account_id => 2, :main_id => main_2.id
+    assert_equal 0, main_2.sevenths.count
+
+    main_3 = Main.create!(account_id: 1, aux: false)
+    seventh_3 = Seventh.create! :account_id => 2, :main_id => main_3.id
+    assert_equal [seventh_3], main_3.sevenths
   end
 end


### PR DESCRIPTION
## Description

Adding an `inherit_if` option that allows us to skip the `inherit` logic under certain circumstances.

Since not all our models inherit we want to opt some out.
```
belongs_to :product, inherit: :user_id, inherit_if: ->(p) { p.account_id != -1 }
```