### PR TITLE
Include support for Rails 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,13 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.4
-          - 2.5
-          - 2.6
+          - 2.7
         gemfile:
-          - rails4.2
           - rails5.0
           - rails5.1
           - rails5.2
+          - rails6.0
+          - rails6.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  - Makes models inherit specified attributes from an association.
  - Scope queries by inherited attributes
 
-Supports ActiveRecord 3.2, 4.1, 4.2, 5.0
+Supports ActiveRecord 5.0, 5.1, 5.2, 6.0, 6.1
 
 ## Install
 
@@ -44,7 +44,7 @@ This will not use the attribute to query, so it might use a different index and 
 
 #### Allowed list of values (inherit_allowed_list)
 
-In some occasions, there are values that we don't want to filter out, even if they don't correspond to the inherited one. 
+In some occasions, there are values that we don't want to filter out, even if they don't correspond to the inherited one.
 Following the previous Post example, this could happen if we have a universal "system" category belonging to no account, one that we associated to all the posts that have no other category. A way to keep this category (assuming that it has the account_id `-1`) would look like this:
 
 ```Ruby
@@ -55,7 +55,7 @@ end
 
 ## Copyright and license
 
-Copyright 2015 Zendesk
+Copyright 2022 Zendesk
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/active_record_inherit_assoc.gemspec
+++ b/active_record_inherit_assoc.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new name, "2.10.0" do |s|
   s.license = "Apache License Version 2.0"
   s.homepage = "https://github.com/zendesk/#{name}"
 
-  s.add_runtime_dependency 'activerecord', '>= 4.2.0', '< 5.3'
-  s.required_ruby_version = '>= 2.4'
+  s.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 6.2'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-rg'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,4 +1,0 @@
-eval_gemfile('common.rb')
-
-gem 'activerecord', '~> 4.2.5', :require=> 'active_record'
-gem 'sqlite3', '~> 1.3', '< 1.4'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile('common.rb')
+
+gem 'activerecord', '~> 6.0.0', require: 'active_record'
+gem 'rails',        '~> 6.0.0'

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,4 @@
+eval_gemfile('common.rb')
+
+gem 'activerecord', '~> 6.1.0', require: 'active_record'
+gem 'rails',        '~> 6.1.0'

--- a/lib/active_record_inherit_assoc.rb
+++ b/lib/active_record_inherit_assoc.rb
@@ -1,20 +1,14 @@
 require 'active_record'
 
-case ActiveRecord::VERSION::MAJOR
-when 4
-  ActiveRecord::Associations::Builder::Association.valid_options << :inherit
-  ActiveRecord::Associations::Builder::Association.valid_options << :inherit_allowed_list
-when 5
-  # We can't add options into `valid_options` anymore.
-  # Here are the possible solutions:
-  #   * monkey patch Assocition::VALID_OPTIONS
-  #   * prepend the `valid_options` method
-  #   * create an Extension class and add it via ActiveRecord::Associations::Builder::Association.extensions
-  #
-  # I went with the first one out of simplicity.
-  ActiveRecord::Associations::Builder::Association::VALID_OPTIONS << :inherit
-  ActiveRecord::Associations::Builder::Association::VALID_OPTIONS << :inherit_allowed_list
+module ActiveRecordInheritBuildAssocPrepend
+  INHERIT_OPTIONS = %i[inherit inherit_allowed_list].freeze
+
+  def valid_options(options)
+    super + INHERIT_OPTIONS
+  end
 end
+
+ActiveRecord::Associations::Builder::Association.singleton_class.prepend(ActiveRecordInheritBuildAssocPrepend)
 
 module ActiveRecordInheritAssocPrepend
   def target_scope


### PR DESCRIPTION
#### Description
This gem currently is not supported by Rails 6, and blocking our Rails upgrade on [SMS](https://github.com/zendesk/sms). This PR includes support for Rails 6, by module-prepending the `ActiveRecord::Associations::Builder::Association#valid_options` method to include the inherit values as valid options.

This PR also removes support for Rails 4.2, and Ruby versions < 2.7.

<!--
#### Manifest Generation
PLEASE READ - Something be aware of, manifest generation is done via a separate branch as part of a GitHub Action. You can see your created branch with the manifests generated by checking against this pattern $YOUR_BRANCH_NAME-deploy.

#### Github Actions Labels
Here are the labels you can use to skip certain actions:
skip_deploy - Use this if your code does not impact production (new strings not in use, changes to testing, etc), skips all actions
release_in_batch - Add this label to all the PRs in the batch except the last one, as the last one will trigger a release
skip_manifest_generation - Use this to skip manifest generation. Good for OPs use
skip_release - Don't bump the release
skip_auto_deploy - Don't automatically deploy
-->

#### Steps to reproduce
1. Set the `Gemfile` as either Rails 6 or Rails 6.1
2. Tests should pass as before

The solution was also tested and confirmed to working on SMS running on Rails 6.

#### References
* JIRA: https://zendesk.atlassian.net/browse/TALK-12183
