### PR TITLE
Add back Ruby 2.6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,32 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
-          - 2.7
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
         gemfile:
           - rails5.0
           - rails5.1
           - rails5.2
           - rails6.0
           - rails6.1
+        exclude:
+          - ruby: '3.0'
+            gemfile: rails5.0
+          - ruby: '3.0'
+            gemfile: rails5.1
+          - ruby: '3.0'
+            gemfile: rails5.2
+          - ruby: '3.1'
+            gemfile: rails5.0
+          - ruby: '3.1'
+            gemfile: rails5.1
+          - ruby: '3.1'
+            gemfile: rails5.2
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval_gemfile('gemfiles/rails4.2.gemfile')
+eval_gemfile('gemfiles/rails5.2.gemfile')

--- a/active_record_inherit_assoc.gemspec
+++ b/active_record_inherit_assoc.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new name, "2.11.0" do |s|
   s.homepage = "https://github.com/zendesk/#{name}"
 
   s.add_runtime_dependency 'activerecord', '>= 5.0.0', '< 6.2'
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'minitest-rg'


### PR DESCRIPTION
Also, test with newer versions of Ruby.

It would be nice to have a version of this gem that works with Ruby 2.6 _and_ with Rails 6.x. Why? I have a few embarrassingly old projects running Ruby 2.6 and Rails 5.x 🙀 