### PR TITLE
Add workflow for publishing to rubygems.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish Gem
+
+on:
+  push:
+    tags: v*
+
+jobs:
+  call-workflow:
+    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
+    secrets:
+      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
+      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'bump/tasks'
 
+# Pushing to rubygems is handled by a github workflow
+ENV['gem_push'] = 'false'
+
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/test*.rb'


### PR DESCRIPTION
Creates a workflow for publishing to the public Zendesk RubyGems account.

Uses the workflow from the public `gw` gem. `gw`'s (ruby-gem-publication readme](https://github.com/zendesk/gw/blob/main/ruby-gem-publication/README.md)