### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,26 @@
-name: Publish Gem
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/active_record_inherit_assoc/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          ruby-version: "3.4"
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ gem install active_record_inherit_assoc
 ## Usage
 
 ### Filling inherited attributes on initialization:
-```Ruby
+
+```ruby
 # parent_name - The Symbol name of the parent association.
 # options     - The Hash options to use:
 #               :attr - A Symbol or an Array of Symbol names of the attributes
@@ -26,7 +27,7 @@ end
 
 ### Scoping queries
 
-```Ruby
+```ruby
 class Post < ActiveRecord::Base
   has_many :categories, inherit: :account_id
 end
@@ -45,11 +46,26 @@ This will not use the attribute to query, so it might use a different index and 
 In some occasions, there are values that we don't want to filter out, even if they don't correspond to the inherited one.
 Following the previous Post example, this could happen if we have a universal "system" category belonging to no account, one that we associated to all the posts that have no other category. A way to keep this category (assuming that it has the account_id `-1`) would look like this:
 
-```Ruby
+```ruby
 class Post < ActiveRecord::Base
   has_many :categories, inherit: :account_id, inherit_allowed_list: [-1]
 end
 ```
+
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. update version in all `Gemfile.lock` files,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/active_record_inherit_assoc/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/active_record_inherit_assoc/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ## Copyright and license
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,6 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'bump/tasks'
 
-# Pushing to rubygems is handled by a github workflow
-ENV['gem_push'] = 'false'
-
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/test*.rb'

--- a/active_record_inherit_assoc.gemspec
+++ b/active_record_inherit_assoc.gemspec
@@ -1,6 +1,8 @@
+require_relative "lib/active_record_inherit_assoc/version"
+
 name = "active_record_inherit_assoc"
 
-Gem::Specification.new name, "2.14.0" do |s|
+Gem::Specification.new name, ActiveRecordInheritAssoc::VERSION do |s|
   s.summary = "Attribute inheritance for AR associations"
   s.authors = ["Ben Osheroff"]
   s.email = ["ben@gimbo.net"]

--- a/lib/active_record_inherit_assoc/version.rb
+++ b/lib/active_record_inherit_assoc/version.rb
@@ -1,0 +1,3 @@
+module ActiveRecordInheritAssoc
+  VERSION = "2.14.0"
+end


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.

`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [x] Release description has been updated correctly.